### PR TITLE
Update mm.inc.php

### DIFF
--- a/assets/plugins/managermanager/mm.inc.php
+++ b/assets/plugins/managermanager/mm.inc.php
@@ -129,6 +129,7 @@ foreach ($all_tvs as $thisTv){
 		case 'rawtextarea':
 		case 'textareamini':
 		case 'richtext':
+		case 'custom_tv':
 			$t = 'textarea';
 		break;
 		


### PR DESCRIPTION
custom_tv type should use textarea, otherwise it is difficult to have " and ' as value in a custom tv. This is important for multiTV and other custom template variables that use json content.

The rules of mm_hidefield use the tv type to hide the tv and multiTV is not hideable. Some other field rules have the issue too.
